### PR TITLE
Only update user once we have the flags for that user.

### DIFF
--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -407,6 +407,23 @@ describe('LDClient', () => {
   });
 
   describe('identify', () => {
+    it('does not set user until the flag config has been updated', async () => {
+      function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+      }
+
+      const user2 = { key: 'user2' };
+      const client = platform.testing.makeClient(envName, user);
+      await client.waitForInitialization();
+      server.autoRespond = false;
+      const identifyPromise = client.identify(user2);
+      await sleep(200); // sleep to jump some async ticks.
+      expect(client.getUser()).toEqual(user);
+      server.respond();
+      await identifyPromise;
+      expect(client.getUser()).toEqual(user2);
+    });
+
     it('updates flag values when the user changes', async () => {
       const user2 = { key: 'user2' };
       const client = platform.testing.makeClient(envName, user);

--- a/src/index.js
+++ b/src/index.js
@@ -191,8 +191,16 @@ export function initialize(env, user, specifiedOptions, platform, extraDefaults)
     return utils.wrapPromiseCallback(
       clearFirst
         .then(() => userValidator.validateUser(user))
-        .then(realUser => ident.setUser(realUser))
-        .then(() => requestor.fetchFlagSettings(ident.getUser(), hash))
+        .then(realUser =>
+          requestor.fetchFlagSettings(realUser, hash).then(requestedFlags => ({ requestedFlags, realUser }))
+        )
+        .then(({ requestedFlags, realUser }) => {
+          ident.setUser(realUser);
+          return requestedFlags;
+        })
+
+        // .then(realUser => ident.setUser(realUser))
+        // .then(() => requestor.fetchFlagSettings(ident.getUser(), hash))
         .then(requestedFlags => {
           const flagValueMap = utils.transformVersionedValuesToValues(requestedFlags);
           if (requestedFlags) {

--- a/src/index.js
+++ b/src/index.js
@@ -198,9 +198,6 @@ export function initialize(env, user, specifiedOptions, platform, extraDefaults)
           ident.setUser(realUser);
           return requestedFlags;
         })
-
-        // .then(realUser => ident.setUser(realUser))
-        // .then(() => requestor.fetchFlagSettings(ident.getUser(), hash))
         .then(requestedFlags => {
           const flagValueMap = utils.transformVersionedValuesToValues(requestedFlags);
           if (requestedFlags) {

--- a/src/index.js
+++ b/src/index.js
@@ -195,11 +195,8 @@ export function initialize(env, user, specifiedOptions, platform, extraDefaults)
           requestor.fetchFlagSettings(realUser, hash).then(requestedFlags => ({ requestedFlags, realUser }))
         )
         .then(({ requestedFlags, realUser }) => {
-          ident.setUser(realUser);
-          return requestedFlags;
-        })
-        .then(requestedFlags => {
           const flagValueMap = utils.transformVersionedValuesToValues(requestedFlags);
+          ident.setUser(realUser);
           if (requestedFlags) {
             return replaceAllFlags(requestedFlags).then(() => flagValueMap);
           } else {


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
I am mostly opening this to have a repro case for a problem we have with the js client.

We use the data export feature to get feature events into our DWH. We have enabled the option to include the whole user object in these events in order to get a better picture of why a certain variation got picked etc. However it seems that the user that is being included don't necessarily have to be the user that fetched the flag settings. In particular when we call `identify`, the sdk will update the user before the flag settings have started to take effect. This means that our events will have the new user but the old flag config. 

**Describe the solution you've provided**
I changed so that the user is only updated when the flag settings have been updated.

**Describe alternatives you've considered**
None, I am happy to hear your thoughts here.
