### PR TITLE
remove unused babel polyfill dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,15 +970,6 @@
 				}
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
-			"integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.2"
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
@@ -2753,6 +2744,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -2797,7 +2789,8 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-glob": {
 					"version": "4.0.1",
@@ -3026,11 +3019,6 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
-		},
-		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
 		},
 		"core-js-compat": {
 			"version": "3.3.5",
@@ -7400,7 +7388,8 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"braces": {
 					"version": "2.3.2",
@@ -7663,7 +7652,8 @@
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
@@ -7722,7 +7712,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "typescript": "3.0.1"
   },
   "dependencies": {
-    "@babel/polyfill": "7.6.0",
     "base64-js": "1.3.0",
     "fast-deep-equal": "2.0.1",
     "uuid": "3.3.2"


### PR DESCRIPTION
babel polyfill is not used, but package.json has a dependency on it. This removes it so that the package doesn't pull it in unnecessarily.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**
remove an unused dependency on babel polyfill

Provide a clear and concise description of what you expect to happen.
nothing


