### PR TITLE
Add failing test for reason change

### DIFF
--- a/src/__tests__/LDClient-streaming-test.js
+++ b/src/__tests__/LDClient-streaming-test.js
@@ -330,6 +330,22 @@ describe('LDClient streaming', () => {
       });
     });
 
+    it('fires individual change event when flag reasons are updated from put event', async () => {
+      await withClientAndServer({ bootstrap: { flagKey: true }, evaluationReasons: true }, async client => {
+        await client.waitForInitialization();
+
+        const receivedChange = eventSink(client, 'change:flagKey');
+
+        const stream = await expectStreamConnecting(fullStreamUrlWithUser + '?withReasons=true');
+        stream.eventSource.mockEmit('put', {
+          data: '{"flagKey":{"value":true,"version":2, "reason": {"kind": "FALLTHROUGH"}}}',
+        });
+
+        const args = await receivedChange.take();
+        expect(args).toEqual([true, true]);
+      });
+    });
+
     it('handles patch message by updating flag', async () => {
       await withClientAndServer({ bootstrap: { flagKey: false } }, async client => {
         await client.waitForInitialization();


### PR DESCRIPTION
I just wanted to highlight a behaviour in the SDK that isn't ideal for our use case.

Essentially we rely on the `change:<flag-key>` event to know when we should run `variationDetail` to get the latest flag details. However, this event is not triggered when the reason property changes. As such, we can't know if the reason we currently have is the most recent one. I guess we can workaround this by polling `variationDetail`, but I find that to defeat the purpose of the change event. 