### PR TITLE
Take the reason and user into account when caching events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,9 +145,8 @@ export function initialize(env, user, specifiedOptions, platform, extraOptionDef
   function sendFlagEvent(key, detail, defaultValue, includeReason) {
     const user = ident.getUser();
     const now = new Date();
-    const value = detail ? detail.value : null;
     if (!options.allowFrequentDuplicateEvents) {
-      const cacheKey = JSON.stringify(value) + (user && user.key ? user.key : '') + key; // see below
+      const cacheKey = JSON.stringify(detail) + JSON.stringify(user) + key; // see below
       const cached = seenRequests[cacheKey];
       // cache TTL is five minutes
       if (cached && now - cached < 300000) {
@@ -160,7 +159,7 @@ export function initialize(env, user, specifiedOptions, platform, extraOptionDef
       kind: 'feature',
       key: key,
       user: user,
-      value: value,
+      value: detail ? detail.value : null,
       variation: detail ? detail.variationIndex : null,
       default: defaultValue,
       creationDate: now.getTime(),


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

We would like the data export to contain events tracking all relevant changes, not only for those concerned with the variation. In particular, we are interested in any changes to the user object. To this end, we call `featureVariation` whenever we detect such a relevant change. However, due to the current caching logic, events are discarded if they do not differ in the feature key, feature value, and user key. In addition, we are also interested in changes to the evaluation reason.

The proposed solution is to stringify both `detail` and `user` as they are.

**Describe alternatives you've considered**

One could enable `allowFrequentDuplicateEvents`; however, this would lead to many additional events being generated, and the data-export feature is charged by the number of events.