### PR TITLE
Add null to LDEvaluationDetail.reason type

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -409,7 +409,7 @@ declare module 'launchdarkly-js-sdk-common' {
 
     /**
      * An object describing the main factor that influenced the flag evaluation value.
-     * Will be `null` if the `evaluationReasons` client option is `false`.
+     * Will be `null` if `[[LDOptions.evaluationReasons]]` is `false`.
      */
     reason: LDEvaluationReason | null;
   }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -409,8 +409,9 @@ declare module 'launchdarkly-js-sdk-common' {
 
     /**
      * An object describing the main factor that influenced the flag evaluation value.
+     * Will be `null` if the `evaluationReasons` client option is `false`.
      */
-    reason: LDEvaluationReason;
+    reason: LDEvaluationReason | null;
   }
 
   /**


### PR DESCRIPTION
**Requirements**

- [ ] ~I have added test coverage for new or changed functionality~
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

I noticed that the type of `LDEvaluationDetail['reason']` is incomplete.  In the code, `detail.reason` can be `null` ([ref](https://github.com/launchdarkly/js-sdk-common/blob/master/src/index.js#L279)) when `evaluateReasons` is `false`, but in the typings it is listed as required.

This PR changes the type of `LDEvaluationDetail['reason']` to include `null`.

**Describe alternatives you've considered**

n/a

**Additional context**

Related Docs PR: https://github.com/launchdarkly/LaunchDarkly-Docs/pull/80
