### PR TITLE
Fix typo in LDClient.on jsdoc

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -611,7 +611,7 @@ declare module 'launchdarkly-js-sdk-common' {
     /**
      * Registers an event listener.
      *
-     * The following event names (keys) are used by the cliet:
+     * The following event names (keys) are used by the client:
      *
      * - `"ready"`: The client has finished starting up. This event will be sent regardless
      *   of whether it successfully connected to LaunchDarkly, or encountered an error


### PR DESCRIPTION
**Additional context**

This is a tiny typo fix in the typings for `LDClient.on`.