### PR TITLE
Log when respecting the Do-Not-Track header

### DIFF
--- a/src/__tests__/LDClient-events-test.js
+++ b/src/__tests__/LDClient-events-test.js
@@ -274,6 +274,7 @@ describe('LDClient events', () => {
         await client.identify(user1);
 
         expect(ep.events.length).toEqual(0);
+        expect(platform.testing.logger.output.warn).toEqual([messages.doNotTrackEnabled()])
       });
     });
   });

--- a/src/__tests__/LDClient-events-test.js
+++ b/src/__tests__/LDClient-events-test.js
@@ -274,7 +274,13 @@ describe('LDClient events', () => {
         await client.identify(user1);
 
         expect(ep.events.length).toEqual(0);
-        expect(platform.testing.logger.output.warn).toEqual([messages.doNotTrackEnabled()])
+        expect(platform.testing.logger.output.warn).toEqual([messages.doNotTrackEnabled()]);
+
+        // Subsequent calls after the first shouldn't trigger additional
+        // warnings. One is enough; more is just noise.
+        await client.identify(user1);
+        expect(ep.events.length).toEqual(0);
+        expect(platform.testing.logger.output.warn).toEqual([messages.doNotTrackEnabled()]);
       });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ export function initialize(env, user, specifiedOptions, platform, extraOptionDef
   let inited = false;
   let closed = false;
   let firstEvent = true;
+  let hasLoggedDntWarning = false;
 
   // The "stateProvider" object is used in the Electron SDK, to allow one client instance to take partial
   // control of another. If present, it has the following contract:
@@ -118,7 +119,17 @@ export function initialize(env, user, specifiedOptions, platform, extraOptionDef
   }
 
   function shouldEnqueueEvent() {
-    return sendEvents && !closed && !platform.isDoNotTrack();
+    if (!sendEvents || closed) {
+      return false;
+    }
+    if (platform.isDoNotTrack()) {
+      if (!hasLoggedDntWarning) {
+        logger.warn(messages.doNotTrackEnabled());
+        hasLoggedDntWarning = true;
+      }
+      return false;
+    }
+    return true;
   }
 
   function enqueueEvent(event) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -110,6 +110,10 @@ export const identifyDisabled = function() {
   return 'identify() has no effect here; it must be called on the main client instance';
 };
 
+export const doNotTrackEnabled = function() {
+  return 'Not sending events to LaunchDarkly because Do Not Track is enabled.';
+};
+
 export const streamClosing = function() {
   return 'Closing stream connection';
 };

--- a/src/messages.js
+++ b/src/messages.js
@@ -111,7 +111,7 @@ export const identifyDisabled = function() {
 };
 
 export const doNotTrackEnabled = function() {
-  return 'Not sending events to LaunchDarkly because Do Not Track is enabled.';
+  return 'LaunchDarkly events will not be sent because this browser's Do Not Track setting is enabled.';
 };
 
 export const streamClosing = function() {

--- a/src/messages.js
+++ b/src/messages.js
@@ -111,7 +111,7 @@ export const identifyDisabled = function() {
 };
 
 export const doNotTrackEnabled = function() {
-  return 'LaunchDarkly events will not be sent because this browser's Do Not Track setting is enabled.';
+  return "LaunchDarkly events will not be sent because this browser's Do Not Track setting is enabled.";
 };
 
 export const streamClosing = function() {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] <s>I have validated my changes against all supported platform versions</s> - nope, sorry. See below.

**Related issues**

I haven't opened any.

**Motivation**

Currently, if a developer has Do-Not-Track enabled on their browser, the js-client-sdk simply silently fails to send any events to LaunchDarkly with no explanation of why. It *is* mentioned in the docs that LaunchDarkly respects Do-Not-Track, but a dev who hasn't seen that line in the docs, doesn't remember it, or incorrectly believes that their browser doesn't have Do-Not-Track enabled can still be caught out. Both I and another dev I work with burned a few hours on this.

**Describe the solution you've provided**

I've made it so that the first time an event isn't sent due to Do-Not-Track being enabled, a warning about this gets logged. That should tip off devs with Do-Not-Track enabled to the reason that stuff isn't working for them.

**Describe alternatives you've considered**

I can't think of any.

**Additional context**

I failed to test this manually. I tried to use my fork in a repo from work where we use LaunchDarkly by using `"launchdarkly-js-sdk-common": "git+https://github.com/ExplodingCabbage/js-sdk-common.git"` in my `package.json`, but the install failed with some sort of build error from js-sdk-common about a failed file rename:

```
$ yarn
➤ YN0000: ┌ Project validation
➤ YN0057: │ @curative/scheduler_v2_web: Resolutions field will be ignored
➤ YN0000: └ Completed
➤ YN0000: ┌ Resolution step
➤ YN0013: │ launchdarkly-js-sdk-common@https://github.com/ExplodingCabbage/js-sdk-common.git#commit=eb708e021fe33b38e7c4f5a4b970b7dfe718b24f can't be found in the cache and will be fetched from GitHub
➤ YN0013: │ launchdarkly-js-sdk-common@https://github.com/ExplodingCabbage/js-sdk-common.git#commit=eb708e021fe33b38e7c4f5a4b970b7dfe718b24f can't be found in the cache and will be fetched from the remote repository
➤ YN0001: │ Error: launchdarkly-js-sdk-common@https://github.com/ExplodingCabbage/js-sdk-common.git#commit=eb708e021fe33b38e7c4f5a4b970b7dfe718b24f: ENOENT: no such file or directory, rename '/tmp/xfs-b352d5b1/┌────────────────────────────────────────────┐
│                                            │
│   Destination: ./dist/ldclient-common.js   │
│   Bundle Size:  115.61 KB                  │
│   Minified Size:  37.88 KB                 │
│   Gzipped Size:  14.03 KB                  │
│                                            │
└────────────────────────────────────────────┘
┌──────────────────────────────────────────────┐
│                                              │
│   Destination: dist/ldclient-common.cjs.js   │
│   Bundle Size:  109.34 KB                    │
│   Minified Size:  44.18 KB                   │
│   Gzipped Size:  14.7 KB                     │
│                                              │
└──────────────────────────────────────────────┘
┌─────────────────────────────────────────────┐
│                                             │
│   Destination: dist/ldclient-common.es.js   │
│   Bundle Size:  109.17 KB                   │
│   Minified Size:  44.03 KB                  │
│   Gzipped Size:  14.66 KB                   │
│                                             │
└─────────────────────────────────────────────┘
launchdarkly-js-sdk-common-3.3.3.tgz' -> '/tmp/xfs-b352d5b1/package.tgz'
➤ YN0000: └ Completed in 33s 962ms
➤ YN0000: Failed with errors in 33s 966ms
```

I didn't fancy spending time debugging that and didn't see any guidance on how to do manual testing in CONTRIBUTING.md, so I thought I'd leave it to y'all to manually validate the change, if that's alright with you!
