### PR TITLE
Remove flatMap usage

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -17,9 +17,10 @@ function getLDHeaders(platform, options) {
   if (tagKeys.length) {
     h['x-launchdarkly-tags'] = tagKeys
       .sort()
-      .flatMap(
+      .map(
         key => (Array.isArray(tags[key]) ? tags[key].sort().map(value => `${key}/${value}`) : [`${key}/${tags[key]}`])
       )
+      .reduce((flattened, item) => flattened.concat(item), [])
       .join(' ');
   }
   return h;


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

I've replaced `flatMap` usage with simple `map` and `reduce` to support older browsers.

**Describe alternatives you've considered**

It is possible to add `flatMap` polyfill to the project but as it is only one usage of `flatMap` function it doesn't make any sense in my opinion. 

**Additional context**

I noticed `o.sort(...).flatMap is not a function` error in my project in case of older browser (for example Chrome Mobile 66).
