### PR TITLE
Fix anchor for error message URL

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -15,7 +15,7 @@ const clientInitialized = function() {
 };
 
 const docLink =
-  ' Please see https://docs.launchdarkly.com/sdk/client-side/javascript#initializing-the-client for instructions on SDK initialization.';
+  ' Please see https://docs.launchdarkly.com/sdk/client-side/javascript#initialize-the-client for instructions on SDK initialization.';
 
 const clientNotReady = function() {
   return 'LaunchDarkly client is not ready';


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

I have not created an issue, but let me know if you want me to.

**Describe the solution you've provided**

I'm fixing the anchor link reported in the console.  There was a [change](https://github.com/launchdarkly/LaunchDarkly-Docs/commit/60a05c9244607a6965958f17f2557ba6bc24dc83#diff-26abf752171a35488030dbdd7fdc6713bd491d480b47d226ca912226ef970bbfR238) last year in the (now deprecated) docs and it looks like the anchor hasn't been updated in the SDK.

This change will fix the URL:

Before: [Link](https://docs.launchdarkly.com/sdk/client-side/javascript#initializing-the-client)

After: [Link](https://docs.launchdarkly.com/sdk/client-side/javascript#initialize-the-client)

Nothing ground breaking here.

**Describe alternatives you've considered**

An alternative would be to update the docs to change the anchor link back.  I'm not sure if the new docs are public to suggest that change, or if that's what your team wants.  There are other places that reference the old anchor link including a [DataDog](https://docs.datadoghq.com/real_user_monitoring/guide/setup-feature-flag-data-collection/?tab=browser#launchdarkly-integration) page about integrating with LaunchDarkly ([code](https://github.com/DataDog/documentation/blob/099a849767b047283496097ac209f43882f49d6e/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md?plain=1#L384)).

**Additional context**

- I didn't add a test or update one, it doesn't appear these messages are tested so I left it as is.
- I did not validate my changes against all supported platform versions.  I would hope it's safe.
