### PR TITLE
fix: Add hooks to default options to prevent warning.

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -37,6 +37,7 @@ const baseOptionDefs = {
   stateProvider: { type: 'object' }, // not a public option, used internally
   application: { validator: applicationConfigValidator },
   inspectors: { default: [] },
+  hooks: { default: [] },
 };
 
 /**


### PR DESCRIPTION
Adds hooks to the default options. Currently a warning would be emitted when specifying hooks, but they would work properly.