### PR TITLE
ci: Add dependency-scan GitHub Actions workflow

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -10,7 +10,7 @@ jobs:
   generate-nodejs-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
@@ -22,7 +22,7 @@ jobs:
     needs:
       - generate-nodejs-sbom
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Evaluate SBOM Policy
         uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,30 @@
+name: Dependency Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate-nodejs-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
+        with:
+          types: 'nodejs'
+
+  evaluate-policy:
+    runs-on: ubuntu-latest
+    needs:
+      - generate-nodejs-sbom
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Evaluate SBOM Policy
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
+        with:
+          artifacts-pattern: bom-*

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -10,7 +10,7 @@ jobs:
   generate-nodejs-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
@@ -22,7 +22,7 @@ jobs:
     needs:
       - generate-nodejs-sbom
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Evaluate SBOM Policy
         uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to generate Software Bill of Materials (SBOM) for Node.js dependencies and evaluate them against security policies as part of SEC-7263.

**Requirements**

- [ ] I have added test coverage for new or changed functionality (N/A - workflow addition)
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions (will be validated in CI)

**Related issues**

Security ticket: SEC-7263

**Describe the solution you've provided**

This PR adds a new GitHub Actions workflow (`.github/workflows/dependency-scan.yml`) that:

1. **Generates SBOM**: Uses `launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main` to create a Software Bill of Materials for all Node.js dependencies
2. **Evaluates Policy**: Uses `launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main` to check the generated SBOM against LaunchDarkly's security policies
3. **Triggers**: Runs on pull requests and pushes to the main branch to ensure continuous security monitoring

The workflow follows a two-job pattern where SBOM generation runs first, then policy evaluation depends on the generated artifacts.

**Critical items for review**

- **Artifact passing**: Verify that the `artifacts-pattern: bom-*` in the evaluate-policy job correctly matches the artifacts generated by the SBOM generation step
- **Action versions**: The workflow uses `@main` instead of pinned versions - confirm this aligns with security practices
- **Workflow triggers**: Validate that running on both PR and main branch pushes is appropriate for this repository
- **Public action usage**: Confirm `launchdarkly/gh-actions` is the correct action repository for this public repo (vs `launchdarkly/common-actions` for private repos)

**Additional context**

This change was implemented as part of a systematic rollout of dependency scanning across LaunchDarkly's npm ecosystem repositories. The workflow uses public GitHub Actions (`launchdarkly/gh-actions`) since this is a public repository.

Link to Devin run: https://app.devin.ai/sessions/434bb14b7bac4d81b9979b88965be92b
Requested by: @pkaeding