### PR TITLE
fix: attribute key that is prefixed with `/` are not redacted when `allAttributesPrivate` is set to `true`

### DIFF
--- a/src/ContextFilter.js
+++ b/src/ContextFilter.js
@@ -18,7 +18,7 @@ function ContextFilter(config) {
    */
   const getAttributesToFilter = (context, redactAnonymous) =>
     (allAttributesPrivate || (redactAnonymous && context.anonymous)
-      ? Object.keys(context)
+      ? Object.keys(context).map(key => (key.startsWith('/') ? AttributeReference.literalToReference(key) : key))
       : [...privateAttributes, ...((context._meta && context._meta.privateAttributes) || [])]
     ).filter(attr => !protectedAttributes.some(protectedAttr => AttributeReference.compare(attr, protectedAttr)));
 

--- a/src/__tests__/ContextFilter-test.js
+++ b/src/__tests__/ContextFilter-test.js
@@ -171,6 +171,43 @@ describe('when handling legacy user contexts', () => {
     );
   });
 
+  it('redacts attribute names with a preceding slash when allAttributesPrivate is true', () => {
+    const uf = ContextFilter({ allAttributesPrivate: true });
+    expect(
+      uf.filter({
+        key: 'abc',
+        custom: { '/ssn': '123-45-6789', bizzle: 'def' },
+      })
+    ).toEqual({
+      kind: 'user',
+      key: 'abc',
+      _meta: {
+        redactedAttributes: ['/bizzle', '/~1ssn'],
+      },
+    });
+  });
+
+  it('redacts attribute names with a preceding slash when redactAnonymous is true for an anonymous context', () => {
+    const uf = ContextFilter({});
+    expect(
+      uf.filter(
+        {
+          key: 'abc',
+          anonymous: true,
+          custom: { '/ssn': '123-45-6789', bizzle: 'def' },
+        },
+        true
+      )
+    ).toEqual({
+      kind: 'user',
+      key: 'abc',
+      anonymous: true,
+      _meta: {
+        redactedAttributes: ['/bizzle', '/~1ssn'],
+      },
+    });
+  });
+
   it.each([null, undefined])('handles null and undefined the same for built-in attributes', value => {
     const cf = ContextFilter({});
     const user = {
@@ -300,6 +337,24 @@ describe('when handling single kind contexts', () => {
       kind: 'user',
       key: 'user',
       anonymous: false,
+    });
+  });
+
+  it('redacts single-kind attribute names with a preceding slash when allAttributesPrivate is true', () => {
+    const uf = ContextFilter({ allAttributesPrivate: true });
+    expect(
+      uf.filter({
+        kind: 'organization',
+        key: 'abc',
+        '/ssn': '123-45-6789',
+        name: 'Alice',
+      })
+    ).toEqual({
+      kind: 'organization',
+      key: 'abc',
+      _meta: {
+        redactedAttributes: ['/name', '/~1ssn'],
+      },
     });
   });
 });
@@ -456,5 +511,20 @@ describe('when handling mult-kind contexts', () => {
   it('it should apply global private attributes to all contexts.', () => {
     const uf = ContextFilter({ privateAttributes: ['name'] });
     expect(uf.filter(orgAndUserContext)).toEqual(orgAndUserGlobalNamePrivate);
+  });
+
+  it('it should redact attribute names with a preceding slash in every sub-context when all attributes are private.', () => {
+    const uf = ContextFilter({ allAttributesPrivate: true });
+    expect(
+      uf.filter({
+        kind: 'multi',
+        user: { key: 'u', '/private_token': 'SECRET-TOKEN', name: 'A' },
+        org: { key: 'o', '/api_key': 'SECRET-API', name: 'O' },
+      })
+    ).toEqual({
+      kind: 'multi',
+      user: { key: 'u', _meta: { redactedAttributes: ['/name', '/~1private_token'] } },
+      org: { key: 'o', _meta: { redactedAttributes: ['/name', '/~1api_key'] } },
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted change to privacy redaction with new tests; fixes a data-leak bug without altering unrelated filtering paths.
> 
> **Overview**
> When **`allAttributesPrivate`** is on or **anonymous redaction** applies, attribute names that literally start with `/` were not always stripped because `getAttributesToFilter` used raw `Object.keys` values while redaction compares **attribute references** (e.g. `/ssn` → `/~1ssn`).
> 
> **`getAttributesToFilter`** now maps keys that start with `/` through **`AttributeReference.literalToReference`**, matching the behavior already used for legacy `privateAttributeNames` and for **`cloneExcluding`**. Legacy users (custom fields), single-kind contexts, and multi-kind sub-contexts all get the same fix.
> 
> Tests cover legacy custom fields, top-level slash keys, anonymous redaction, and multi-kind **`allAttributesPrivate`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7c6faab1fb5ed5d5bec26f5355724e3ecc4c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->