### PR TITLE
fix: secure-mode localstorage cache key does not get updated on new context

### DIFF
--- a/src/PersistentFlagStore.js
+++ b/src/PersistentFlagStore.js
@@ -1,12 +1,15 @@
 const utils = require('./utils');
 
-function PersistentFlagStore(storage, environment, hash, ident) {
+function PersistentFlagStore(storage, environment, getHash, ident) {
   const store = {};
 
   function getFlagsKey() {
     let key = '';
     const context = ident.getContext();
     if (context) {
+      // Read the hash on every call: in secure mode the hash changes when identify() is called, and
+      // this store instance lives for the lifetime of the client.
+      const hash = getHash();
       key = hash || utils.btoa(JSON.stringify(context));
     }
     return 'ld:' + environment + ':' + key;

--- a/src/__tests__/LDClient-localstorage-test.js
+++ b/src/__tests__/LDClient-localstorage-test.js
@@ -151,6 +151,106 @@ describe('LDClient local storage', () => {
       });
     });
 
+    it('should use the new hash as the localStorage key when identify changes the secure mode hash', async () => {
+      const hash1 = 'hash-for-user1';
+      const hash2 = 'hash-for-user2';
+      const lsKeyHash1 = 'ld:' + envName + ':' + hash1;
+      const lsKeyHash2 = 'ld:' + envName + ':' + hash2;
+      const user2 = { key: 'user2' };
+      const flags1 = { 'enable-foo': { value: true } };
+      const flags2 = { 'enable-foo': { value: false } };
+
+      await withServer(async server => {
+        server.byDefault(respondJson(flags1));
+        await withClient(user, { baseUrl: server.url, hash: hash1 }, async client => {
+          await client.waitForInitialization(5);
+
+          await sleepAsync(0); // allow any pending async tasks to complete
+
+          expect(JSON.parse(platform.testing.getLocalStorageImmediately(lsKeyHash1))).toEqual({
+            $schema: 1,
+            ...flags1,
+          });
+
+          server.byDefault(respondJson(flags2));
+          await client.identify(user2, hash2);
+
+          await sleepAsync(0); // allow any pending async tasks to complete
+
+          // The second context's flags must be cached under the second context's hash.
+          const cachedForHash2 = platform.testing.getLocalStorageImmediately(lsKeyHash2);
+          expect(cachedForHash2).toEqual(expect.anything());
+          expect(JSON.parse(cachedForHash2)).toEqual({ $schema: 1, ...flags2 });
+
+          // The first context's cache slot must have been cleared and must not have been reused.
+          expect(platform.testing.getLocalStorageImmediately(lsKeyHash1)).not.toEqual(expect.anything());
+        });
+      });
+    });
+
+    it('does not apply a stale background-refresh response after identify changes context/hash', async () => {
+      const hash1 = 'hash-for-user1';
+      const hash2 = 'hash-for-user2';
+      const lsKeyHash1 = 'ld:' + envName + ':' + hash1;
+      const lsKeyHash2 = 'ld:' + envName + ':' + hash2;
+      const user2 = { key: 'user2' };
+      const cachedFlags1 = '{"$schema": 1, "enable-foo": {"value": "cached-from-user1"}}';
+      const staleFlags1FromServer = { 'enable-foo': { value: 'stale-response-for-user1' } };
+      const flags2 = { 'enable-foo': { value: 'value-for-user2' } };
+
+      platform.testing.setLocalStorageImmediately(lsKeyHash1, cachedFlags1);
+
+      await withServer(async server => {
+        let requestCount = 0;
+        let heldReq, heldResp;
+        server.byDefault((req, resp) => {
+          requestCount++;
+          if (requestCount === 1) {
+            // This is the background refresh issued while bootstrapping from the cached flags
+            // for user1/hash1. Hold it open - we'll resolve it later, after identify() has
+            // already completed for user2/hash2.
+            heldReq = req;
+            heldResp = resp;
+          } else {
+            respondJson(flags2)(req, resp);
+          }
+        });
+
+        await withClient(user, { baseUrl: server.url, hash: hash1 }, async client => {
+          await client.waitForInitialization(5);
+
+          // We're bootstrapped from the cached flags for user1, and the background refresh
+          // request for user1/hash1 is now in flight and held open.
+          expect(client.variation('enable-foo')).toEqual('cached-from-user1');
+
+          // identify() to a new context/hash. This issues and fully completes its own flag
+          // fetch for user2/hash2 while the old background refresh is still pending.
+          await client.identify(user2, hash2);
+
+          await sleepAsync(0); // allow any pending async tasks to complete
+
+          expect(client.variation('enable-foo')).toEqual('value-for-user2');
+          expect(JSON.parse(platform.testing.getLocalStorageImmediately(lsKeyHash2))).toEqual({
+            $schema: 1,
+            ...flags2,
+          });
+
+          // Now release the stale background-refresh response for user1/hash1.
+          respondJson(staleFlags1FromServer)(heldReq, heldResp);
+
+          await sleepAsync(0); // allow any pending async tasks to complete
+
+          // The stale response must not have overwritten the in-memory flags for the
+          // current (user2/hash2) context, nor the current context's localStorage cache slot.
+          expect(client.variation('enable-foo')).toEqual('value-for-user2');
+          expect(JSON.parse(platform.testing.getLocalStorageImmediately(lsKeyHash2))).toEqual({
+            $schema: 1,
+            ...flags2,
+          });
+        });
+      });
+    });
+
     it('should clear localStorage when user context is changed', async () => {
       const lsKey2 = 'ld:UNKNOWN_ENVIRONMENT_ID:' + utils.btoa('{"key":"user2"}');
       const flags = { 'enable-foo': { value: true } };

--- a/src/__tests__/PersistentFlagStore-test.js
+++ b/src/__tests__/PersistentFlagStore-test.js
@@ -15,7 +15,7 @@ describe('PersistentFlagStore', () => {
   it('stores flags', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
 
     const flags = { flagKey: { value: 'x' } };
 
@@ -29,7 +29,7 @@ describe('PersistentFlagStore', () => {
   it('retrieves and parses flags', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
 
     const expected = { flagKey: { value: 'x' } };
     const stored = { $schema: 1, ...expected };
@@ -42,7 +42,7 @@ describe('PersistentFlagStore', () => {
   it('converts flags from old format if schema property is missing', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
 
     const oldFlags = { flagKey: 'x' };
     const newFlags = { flagKey: { value: 'x', version: 0 } };
@@ -55,7 +55,7 @@ describe('PersistentFlagStore', () => {
   it('returns null if storage is empty', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
 
     const values = await store.loadFlags();
     expect(values).toBe(null);
@@ -64,7 +64,7 @@ describe('PersistentFlagStore', () => {
   it('clears storage and returns null if value is not valid JSON', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
 
     platform.testing.setLocalStorageImmediately(lsKey, '{bad');
 
@@ -78,7 +78,7 @@ describe('PersistentFlagStore', () => {
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
     const hash = '12345';
     const keyWithHash = 'ld:' + env + ':' + hash;
-    const store = PersistentFlagStore(storage, env, hash, ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => hash, ident, platform.testing.logger);
 
     const flags = { flagKey: { value: 'x' } };
     await store.saveFlags(flags);
@@ -87,10 +87,58 @@ describe('PersistentFlagStore', () => {
     expect(JSON.parse(value)).toEqual({ $schema: 1, ...flags });
   });
 
+  it('reads the current hash on every call, not the hash at construction time', async () => {
+    const platform = stubPlatform.defaults();
+    const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
+    let hash = 'hash1';
+    const identity = Identity(context);
+    const store = PersistentFlagStore(storage, env, () => hash, identity, platform.testing.logger);
+    const keyWithHash1 = 'ld:' + env + ':hash1';
+    const keyWithHash2 = 'ld:' + env + ':hash2';
+
+    const flags1 = { flagKey: { value: 'x' } };
+    await store.saveFlags(flags1);
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(keyWithHash1))).toEqual({ $schema: 1, ...flags1 });
+
+    hash = 'hash2';
+
+    // saveFlags must write under the new hash
+    const flags2 = { flagKey: { value: 'y' } };
+    await store.saveFlags(flags2);
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(keyWithHash2))).toEqual({ $schema: 1, ...flags2 });
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(keyWithHash1))).toEqual({ $schema: 1, ...flags1 });
+
+    // loadFlags must read under the new hash
+    expect(await store.loadFlags()).toEqual(flags2);
+
+    // clearFlags must clear the new hash's entry only
+    await store.clearFlags();
+    expect(platform.testing.getLocalStorageImmediately(keyWithHash2)).toBe(undefined);
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(keyWithHash1))).toEqual({ $schema: 1, ...flags1 });
+  });
+
+  it('uses the current context on every call when there is no hash', async () => {
+    const platform = stubPlatform.defaults();
+    const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
+    const identity = Identity(context);
+    const store = PersistentFlagStore(storage, env, () => undefined, identity, platform.testing.logger);
+
+    const flags = { flagKey: { value: 'x' } };
+    await store.saveFlags(flags);
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(lsKey))).toEqual({ $schema: 1, ...flags });
+
+    const context2 = { key: 'context-key-2', kind: 'user' };
+    const lsKey2 = 'ld:' + env + ':' + utils.btoa(JSON.stringify(context2));
+    identity.setContext(context2);
+
+    await store.saveFlags(flags);
+    expect(JSON.parse(platform.testing.getLocalStorageImmediately(lsKey2))).toEqual({ $schema: 1, ...flags });
+  });
+
   it('should handle localStorage.get returning an error', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
     const myError = new Error('localstorage getitem error');
     jest.spyOn(platform.localStorage, 'get').mockImplementation(() => Promise.reject(myError));
 
@@ -101,7 +149,7 @@ describe('PersistentFlagStore', () => {
   it('should handle localStorage.set returning an error', async () => {
     const platform = stubPlatform.defaults();
     const storage = PersistentStorage(platform.localStorage, platform.testing.logger);
-    const store = PersistentFlagStore(storage, env, '', ident, platform.testing.logger);
+    const store = PersistentFlagStore(storage, env, () => '', ident, platform.testing.logger);
     const myError = new Error('localstorage setitem error');
     jest.spyOn(platform.localStorage, 'set').mockImplementation(() => Promise.reject(myError));
 

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ function initialize(env, context, specifiedOptions, platform, extraOptionDefs) {
   const ident = Identity(null, onIdentifyChange);
   const anonymousContextProcessor = new AnonymousContextProcessor(persistentStorage);
   const persistentFlagStore = persistentStorage.isEnabled()
-    ? PersistentFlagStore(persistentStorage, environment, hash, ident, logger)
+    ? PersistentFlagStore(persistentStorage, environment, () => hash, ident, logger)
     : null;
 
   function createLogger() {
@@ -727,9 +727,15 @@ function initialize(env, context, specifiedOptions, platform, extraOptionDefs) {
     return persistentFlagStore.loadFlags().then(storedFlags => {
       if (storedFlags === null || storedFlags === undefined) {
         flagStore.setFlags({});
+        const contextAtStart = ident.getContext();
+        const hashAtStart = hash;
         return requestor
-          .fetchFlagSettings(ident.getContext(), hash)
-          .then(requestedFlags => replaceAllFlags(requestedFlags || {}))
+          .fetchFlagSettings(contextAtStart, hashAtStart)
+          .then(requestedFlags => {
+            if (hashAtStart === hash && utils.deepEquals(contextAtStart, ident.getContext())) {
+              return replaceAllFlags(requestedFlags || {});
+            }
+          })
           .then(signalSuccessfulInit)
           .catch(err => {
             const initErr = new errors.LDFlagFetchError(messages.errorFetchingFlags(err));
@@ -742,9 +748,15 @@ function initialize(env, context, specifiedOptions, platform, extraOptionDefs) {
         flagStore.setFlags(storedFlags);
         utils.onNextTick(signalSuccessfulInit);
 
+        const contextAtStart = ident.getContext();
+        const hashAtStart = hash;
         return requestor
-          .fetchFlagSettings(ident.getContext(), hash)
-          .then(requestedFlags => replaceAllFlags(requestedFlags))
+          .fetchFlagSettings(contextAtStart, hashAtStart)
+          .then(requestedFlags => {
+            if (hashAtStart === hash && utils.deepEquals(contextAtStart, ident.getContext())) {
+              return replaceAllFlags(requestedFlags);
+            }
+          })
           .catch(err => emitter.maybeReportError(err));
       }
     });


### PR DESCRIPTION
This PR will make localstorage cache key derive from the current hash
that is passed into the `identify` function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flag caching and init/refresh application logic in the client SDK; wrong behavior could leak or overwrite flag values across contexts, though the change is narrowly scoped with new integration tests.
> 
> **Overview**
> Fixes **secure mode** localStorage caching so cache keys follow the **current** secure hash after `identify()`, instead of the hash captured when the client was created.
> 
> `PersistentFlagStore` now takes a **`getHash` callback** and resolves the storage key on every load/save/clear. The client wires this to the live `hash` variable that `identify()` updates.
> 
> `finishInitWithLocalStorage` also **ignores stale flag fetches**: background refresh responses are applied only if context and hash still match what was in flight when the request started, so a slow refresh for the previous user cannot overwrite flags or cache for the new context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baa41156bd5a3503e91987abd321e570899b84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->